### PR TITLE
perf(matcher): use associative string access instead of `endsWith` in `normalizePath`

### DIFF
--- a/packages/router/src/matcher/matcherTree.ts
+++ b/packages/router/src/matcher/matcherTree.ts
@@ -13,7 +13,7 @@ function normalizePath(path: string) {
   path = path.toUpperCase()
 
   // TODO: Check more thoroughly whether this is really necessary
-  while (path.endsWith('/')) {
+  while (path[path.length - 1] === '/') {
     path = path.slice(0, -1)
   }
 


### PR DESCRIPTION
In my case, this gives double speedup of the `add` function
Current
![image](https://github.com/user-attachments/assets/2ce9a885-a936-4dbb-82bc-f3754768ee5f)
This PR
![image](https://github.com/user-attachments/assets/6e2b5159-92e0-4347-b186-6645454ed764)
